### PR TITLE
Proposed Material signature Rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ no matter where placed. Support lists.
 To find all end-games with white Knight and Bishop plus one optional pawn
 against two black Knights.
 
+##### material-signature
+
+A rule more specialized that 'material'.
+
+   { "material-signature": "QQR0vQRR"}
+
+Finds games where one side has 2 Queens and no Rooks, while
+the other side has 1 Queen and 2 Rooks.
+
+  {"material-signature": "Q0RRBBvQ0RRNN"}
+
+Finds end-games where neither side has a Queen (Q0), and one
+side has 2 Rooks and 2 Bishops, while the other side has
+2 Rooks and 2 Knights.
+
 
 ##### imbalance
 

--- a/src/search.h
+++ b/src/search.h
@@ -22,6 +22,7 @@
 #define SEARCH_H_INCLUDED
 
 #include <atomic>
+#include <map>
 #include <sstream>
 #include <vector>
 
@@ -44,7 +45,8 @@ enum ResultType {
 enum RuleType {
   RuleNone, RulePass, RuleResult, RuleResultType, RuleSubFen, RuleMaterial,
   RuleImbalance, RuleMove, RuleQuietMove, RuleCapturedPiece, RuleMovedPiece,
-  RuleWhite, RuleBlack, RuleMatchedCondition, RuleMatchedQuery
+  RuleWhite, RuleBlack, RuleMatchedCondition, RuleMatchedQuery,
+  RuleMaterialSignature
 };
 
 struct SubFen {
@@ -76,6 +78,12 @@ struct Condition {
   std::vector<ScoutMove> moves;
   std::vector<Key> matKeys;
   std::vector<Imbalance> imbalances;
+
+  // Piece -> # occurrances required.
+  // The value can be zero meaning the piece must be absent.
+  // If an entry is not present then the piece count
+  // is not checked for that piece.
+  std::map<Piece, int> material_signature;
 };
 
 struct MatchingGame {


### PR DESCRIPTION
This is a side effect of my query here:
https://github.com/mcostalba/scoutfish/issues/47#issuecomment-348705395

I wanted to search for a certain pattern (2 Queens vs Q + RR) and it seemed that
the existing rules couldn't do it.

I have done some ad hoc testing of this and it seems to work.

In retrospect possibly the existing "material" rule should be updated instead of a new
rule being added.

For a proper pull I probably need to update the test code - but I've put this together
so it's a kind of working proposal.

I don't use git(hub) much so please bear with me if I'm not following some convention.

thx,
 Dave

Obscure historical note: ages ago I was watching a post mortem at a chess tournament, maybe
a game between 2 masters, and in their analysis there was a position with 2 queens vs
Q+RR and GM Anthony Lein was watching, and they asked him how to evaluate it, and
he said that QQ was usually much better - and ever since Larry Kaufmann wrote those articles
about statistically evaluating material imbalances I've wanted to do it for this probably
rare situation.
